### PR TITLE
ansible_user  -> remote_user as remote_user can be undefined.

### DIFF
--- a/tasks/install-pyenv.yml
+++ b/tasks/install-pyenv.yml
@@ -10,8 +10,8 @@
     file:
       path: '{{ pyenv.path }}'
       state: directory
-      group: '{{ remote_user }}'
-      owner: '{{ remote_user }}'
+      group: '{{ ansible_user }}'
+      owner: '{{ ansible_user }}'
     become: true
 
   - name: Clone pyenv


### PR DESCRIPTION
I ran into an issue where `remote_user` would be undefined which caused the role not to run. I believe you want to use `ansible_user`.

remote_user is also proposed to be deprecated because of various issues: https://github.com/ansible/proposals/issues/89